### PR TITLE
Use standard MQTT connection in agent

### DIFF
--- a/AWSIoTDeviceDefenderAgentSDK/agent.py
+++ b/AWSIoTDeviceDefenderAgentSDK/agent.py
@@ -66,8 +66,8 @@ class IoTClientWrapper(object):
         stream_handler.setFormatter(formatter)
         logger.addHandler(stream_handler)
 
-        self.iot_client = AWSIoTMQTTClient(self.client_id, useWebsocket=True)
-        self.iot_client.configureEndpoint(self.host, 443)
+        self.iot_client = AWSIoTMQTTClient(self.client_id)
+        self.iot_client.configureEndpoint(self.host, 8883)
         self.iot_client.configureCredentials(
             self.root_ca_path, self.private_key_path, self.certificate_path)
 


### PR DESCRIPTION
Description of changes:
The sample agent should default to a standard MQTT connection type and
port, as the instructions in the README describe a regular MQTT
connection scheme.

Remove the useWebsocket flag from client configuration, and set port to default MQTT port

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.