### PR TITLE
Allow comandline parameters to be read from a file

### DIFF
--- a/AWSIoTDeviceDefenderAgentSDK/agent.py
+++ b/AWSIoTDeviceDefenderAgentSDK/agent.py
@@ -81,7 +81,7 @@ class IoTClientWrapper(object):
 
 def parse_args():
     """Setup Commandline Argument Parsing"""
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(fromfile_prefix_chars="@")
     parser.add_argument("-e", "--endpoint", action="store", required=True, dest="endpoint",
                         help="Your AWS IoT custom endpoint")
     parser.add_argument("-r", "--rootCA", action="store", dest="root_ca_path", required=True,


### PR DESCRIPTION
Problem:
There are a lot of commandline arguments for the agent, and it hard to remember them all

Solution:
Allow commandline arguments to be passed via file using Argparse option fromfile_prefix_chars.
More info: https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
