### PR TITLE
Fix incorrect Delta Metric calculation

### DIFF
--- a/AWSIoTDeviceDefenderAgentSDK/metrics.py
+++ b/AWSIoTDeviceDefenderAgentSDK/metrics.py
@@ -59,11 +59,12 @@ class Metrics(object):
         self.listening_udp_ports = []
 
         # Network Stats By Interface
-        self._interface_stats = {}
+        self.total_counts = {}  # The raw values from the system
+        self._interface_stats = {}  # The diff values, if delta metrics are used
         if last_metric is None:
             self._old_interface_stats = {}
         else:
-            self._old_interface_stats = last_metric._interface_stats
+            self._old_interface_stats = last_metric.total_counts
 
         self.max_list_size = 50
 
@@ -121,6 +122,13 @@ class Metrics(object):
         packets_out: int
            Number of packets sent from this interface
         """
+        self.total_counts = {
+            'bytes_in': bytes_in,
+            'bytes_out': bytes_out,
+            'packets_in': packets_in,
+            'packets_out': packets_out
+        }
+
         if self._old_interface_stats:
             bytes_in_diff = bytes_in - self._old_interface_stats[self.t.bytes_in]
             bytes_out_diff = bytes_out - self._old_interface_stats[self.t.bytes_out]

--- a/AWSIoTDeviceDefenderAgentSDK/tests/test_metrics.py
+++ b/AWSIoTDeviceDefenderAgentSDK/tests/test_metrics.py
@@ -206,10 +206,21 @@ def test_network_stats_delta_calculation(simple_metric):
     m2.add_network_stats(bytes_in=125, packets_in=75,
                          bytes_out=225, packets_out=175)
 
+    m3 = metrics.Metrics(last_metric=m2)
+    m3.timestamp = 10
+    m3.interval = 10
+    m3.add_network_stats(bytes_in=150, packets_in=100,
+                         bytes_out=250, packets_out=200)
+
     assert m2.network_stats['bytes_in'] == 25
     assert m2.network_stats['packets_in'] == 25
     assert m2.network_stats['bytes_out'] == 25
     assert m2.network_stats['packets_out'] == 25
+
+    assert m3.network_stats['bytes_in'] == 25
+    assert m3.network_stats['packets_in'] == 25
+    assert m3.network_stats['bytes_out'] == 25
+    assert m3.network_stats['packets_out'] == 25
 
 
 def test_add_network_connections(simple_metric):


### PR DESCRIPTION
Problem:
Delta metrics were not calculated properly because the only the delta value of network stats was persisted in a metrics object.

Solution:
Introduce a second field to store the aggregate network stats, and use that value in delta calculation

Testing:
Introduce a 3rd metric to the delta metrics test to ensure that the delta is not used in subsequent calculations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
