### PR TITLE
Suppress reporting first metric report to correct network stats calcu…

### DIFF
--- a/AWSIoTDeviceDefenderAgentSDK/agent.py
+++ b/AWSIoTDeviceDefenderAgentSDK/agent.py
@@ -151,6 +151,7 @@ if __name__ == '__main__':
     collector = Collector(args.short_tags)
 
     metric = None
+    first_sample = True  # don't publish first sample, so we can accurately report delta metrics
     while True:
         metric = collector.collect_metrics()
         if args.dry_run:
@@ -159,7 +160,9 @@ if __name__ == '__main__':
                 with open("cbor_metrics", "w+b") as outfile:
                     outfile.write(bytearray(metric.to_cbor()))
         else:
-            if args.format == "cbor":
+            if first_sample:
+                first_sample = False
+            elif args.format == "cbor":
                 iot_client.publish(topic, bytearray(metric.to_cbor()))
             else:
                 iot_client.publish(topic, metric.to_json_string())


### PR DESCRIPTION
The network stats metric is a delta metric, and as such for accurate calculation,
the agent will need two samples. This change does not publish the first
sampled metric report, allowing the correct delta network stats to be published.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
