### PR TITLE
Create main functions for Agent and Collector modules

### DIFF
--- a/AWSIoTDeviceDefenderAgentSDK/agent.py
+++ b/AWSIoTDeviceDefenderAgentSDK/agent.py
@@ -117,7 +117,7 @@ def custom_callback(self, userdata, message):
         print("--------------\n\n")
 
 
-if __name__ == '__main__':
+def main():
     # Read in command-line parameters
     args = parse_args()
 
@@ -168,3 +168,7 @@ if __name__ == '__main__':
                 iot_client.publish(topic, metric.to_json_string())
 
         sleep(float(sample_rate))
+
+
+if __name__ == '__main__':
+    main()

--- a/AWSIoTDeviceDefenderAgentSDK/collector.py
+++ b/AWSIoTDeviceDefenderAgentSDK/collector.py
@@ -107,7 +107,7 @@ class Collector(object):
         return metrics_current
 
 
-if __name__ == '__main__':
+def main():
     """Use this method to run the collector in stand-alone mode to test metric collection."""
 
     parser = argparse.ArgumentParser()
@@ -145,3 +145,7 @@ if __name__ == '__main__':
 
         print(metric.to_json_string(pretty_print=True))
         exit()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Move the previously  module-level functionality into main()
functions for both Agent and Collector.  This makes it easier to
trigger standalone mode from other scripts, like those generated
by setuptools.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
