### PR TITLE
Update metrics.py

### DIFF
--- a/AWSIoTDeviceDefenderAgentSDK/metrics.py
+++ b/AWSIoTDeviceDefenderAgentSDK/metrics.py
@@ -114,6 +114,7 @@ class Metrics(object):
         """
         Add cumulative network stats across all network interfaces.
         If a previous metrics object was supplied,attempts to calculate and store delta metric.
+        If a previous metrics object is not present, we do not send any metrics.
 
         Parameters
         ----------
@@ -145,9 +146,7 @@ class Metrics(object):
                                      self.t.packets_out: packets_out_diff}
 
         else:
-            self._interface_stats = {self.t.bytes_in: bytes_in, self.t.bytes_out: bytes_out,
-                                     self.t.packets_in: packets_in,
-                                     self.t.packets_out: packets_out}
+            self._interface_stats = {}
 
     def add_network_connection(self, remote_addr, remote_port, interface, local_port):
         """

--- a/AWSIoTDeviceDefenderAgentSDK/tests/test_collector.py
+++ b/AWSIoTDeviceDefenderAgentSDK/tests/test_collector.py
@@ -234,10 +234,7 @@ def test_collector_collect_network_stats(
     new_collector = collector.Collector(short_metrics_names=False)
     metrics_output = new_collector.collect_metrics()
 
-    assert metrics_output.network_stats["bytes_in"] == 10000
-    assert metrics_output.network_stats["packets_in"] == 30000
-    assert metrics_output.network_stats["bytes_out"] == 20000
-    assert metrics_output.network_stats["packets_out"] == 40000
+    assert len(metrics_output.network_stats) == 0
 
 
 @mock.patch(PATCH_MODULE_LOCATION_PS + "net_if_addrs")

--- a/AWSIoTDeviceDefenderAgentSDK/tests/test_metrics.py
+++ b/AWSIoTDeviceDefenderAgentSDK/tests/test_metrics.py
@@ -94,7 +94,7 @@ def test_v1_metrics_basic_structure_long_names(simple_metric):
 
     metric_block = report[t.metrics]
     # top-level element in metrics block
-    assert t.interface_stats in metric_block
+    assert t.interface_stats not in metric_block
     assert t.listening_tcp_ports in metric_block
     assert t.listening_udp_ports in metric_block
     assert t.tcp_conn in metric_block
@@ -120,7 +120,7 @@ def test_v1_metrics_basic_structure_short_names(simple_metric_short_names):
 
     metric_block = report[t.metrics]
     # top-level element in metrics block
-    assert t.interface_stats in metric_block
+    assert t.interface_stats not in metric_block
     assert t.listening_tcp_ports in metric_block
     assert t.listening_udp_ports in metric_block
     assert t.tcp_conn in metric_block
@@ -136,7 +136,7 @@ def test_v1_metrics_optional_elements(simple_metric):
 
     metric_block = report[t.metrics]
     # top-level element in metrics block
-    assert t.interface_stats in metric_block
+    assert t.interface_stats not in metric_block
     assert t.listening_tcp_ports in metric_block
     assert t.listening_udp_ports in metric_block
     assert t.tcp_conn in metric_block
@@ -235,12 +235,8 @@ def test_add_listening_ports_dedup(simple_metric):
     assert len(simple_metric.listening_udp_ports) == 3
 
 
-def test_basic_add_network_stats(simple_metric):
-    assert len(simple_metric.network_stats) == 4
-    assert simple_metric.network_stats["bytes_in"] == 100
-    assert simple_metric.network_stats["packets_in"] == 50
-    assert simple_metric.network_stats["bytes_out"] == 200
-    assert simple_metric.network_stats["packets_out"] == 150
+def test_initial_network_stat_metrics(simple_metric):
+    assert len(simple_metric.network_stats) == 0
 
 
 def test_timestamp(simple_metric):
@@ -301,7 +297,7 @@ def test_field_sizes():
     assert len(m._net_connections) == 1
     assert len(m.listening_tcp_ports) == 4
     assert len(m.listening_udp_ports) == 3
-    assert len(m.network_stats) == 4
+    assert len(m.network_stats) == 0
 
 
 def test_sampled_lists(simple_metric):

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ AWS IoT Device Defender Agent SDK (Python)
 Example implementation of an AWS IoT Device Defender metrics collection agent,
 and other Device Defender Python samples.
 
+On starting up for the first time - the DD agent publishes the metric values read from the network stats to DD,
+without computing any metric values delta. It does this because when it starts up it does not have any information
+of the previously collected metric values. The side-effect of this is the device's metrics will indicate a large spike each time the device restarts or the agent is restarted which can cause false-positives. Now, we have updated the agent to not send any metrics if it cannot compute the delta.
+
 The provided sample agent can be used as a basis to implement a custom metrics collection agent.
 
 


### PR DESCRIPTION
*Issue #, if available:*
Ref: https://t.corp.amazon.com/V472278982/overview

*Description of changes:*
1. When started up for the first time - publishes the metric values read from the network stats to DD, without performing any metric values delta. It does this because when it starts up it does not have any information of the previously collected metric values.
2. Updating the agent to not send any metrics if it cannot compute the delta
3. Ref CR https://code.amazon.com/reviews/CR-64699254

*Testing
1. Unit tested and tested metric collection locally using the sample agent (Ran the command : https://code.amazon.com/packages/IotDeviceDefenderSdkPython/blobs/5c6371432aa7a3cb5f6bb729099561e6fd8e1819/--/README.rst#L79)
2. Ran the dd sample agent on desktop using the following command - Created a thing and downloaded the rootCA cert, private key and certificate, establised mqtt connection

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
